### PR TITLE
chore: change imperative default to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ jobs:
 ### `imperative`
 
 - **Description**: check commit message is imperative mood.
-- Default: `true`
+- Default: `false`
 
 ### `dry-run`
 

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
   imperative:
     description: check commit message is in imperative mood
     required: false
-    default: true
+    default: false
   dry-run:
     description: run checks without failing
     required: false


### PR DESCRIPTION
To avoid breaking users' workflow like https://github.com/commit-check/commit-check/pull/260, change the imperative default value to false. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default setting for the "imperative" input option in the GitHub Action to "false" instead of "true".
  * Updated documentation to reflect the new default value for the "imperative" input option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->