### PR TITLE
chore: update and rename main.yaml to release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,9 @@
-name: Main
+name: Release
 
 on:
   release:
     branches: [main]
-    types: [published]
+    types: [released]
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
Right now, if we published a pre-release, the tag v1 will also be updated to point to the pre-release. 

which is not what we wanted. We should change the type to [released](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#release)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed the release workflow to “Release” for clearer identification in pipelines.
  * Adjusted the release trigger to run on “released” events instead of “published,” aligning with platform semantics and improving reliability of automated releases.
  * No changes to product functionality; distribution cadence and user experience remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->