### PR TITLE
fix: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: write
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/commit-check/commit-check-action/security/code-scanning/3](https://github.com/commit-check/commit-check-action/security/code-scanning/3)

To fix this issue, add an explicit `permissions` block to the workflow. Since this workflow modifies repository tags, it requires `contents: write`. You can set `permissions` at the workflow root (which applies to all jobs unless overridden) or inside the `re-tag` job. The most maintainable and clear fix is to place the block at the workflow root (after the `name:` and before `on:`), setting `contents: write` (the minimal permission required for tag operations).

No new methods or imports are necessary, since this is a YAML workflow configuration change. All that is needed is to insert the following block:

```yaml
permissions:
  contents: write
```

directly below the `name: Release` declaration at the top of the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated release automation permissions; the workflow token now has write access to repository contents. All existing triggers, jobs, and steps remain unchanged. This affects only the release pipeline and does not alter application behavior or UI. No user-facing changes; functionality, performance, and appearance remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->