### PR TITLE
fix: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,6 @@
 name: Run pre-commit
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/commit-check/commit-check-action/security/code-scanning/2](https://github.com/commit-check/commit-check-action/security/code-scanning/2)

To fix this problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN's privileges to the minimal level necessary. Since the workflow is primarily a pre-commit check (likely only needs to read repository contents), the best starting point is `contents: read`. If additional privileges are confirmed to be required (e.g., opening/modifying PRs), those can be added as needed. 

This change should be made at the root level of `.github/workflows/pre-commit.yml`, immediately after the workflow `name:` line but before `on:`. No additional imports or definitions are required, just a direct YAML addition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub Actions workflow for “Run pre-commit” to explicitly set GITHUB_TOKEN permissions to contents: read.
  * Adjusts the default token scope for this workflow to read-only access to repository contents.
  * Triggers and jobs remain unchanged; this is a configuration-only update.
  * No impact on application features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->