### PR TITLE
fix: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,4 +1,6 @@
 name: Release Drafter
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/commit-check/commit-check-action/security/code-scanning/1](https://github.com/commit-check/commit-check-action/security/code-scanning/1)

To fix the problem, add an explicit `permissions:` block to the workflow. You should add it at the top level (root) of the workflow (just after the `name:` or `on:` block), or if you prefer to give each job specific permissions, to the relevant job(s). The ideal permissions depend on what the workflow does. As a minimal safe starting point, set `contents: read`. This ensures the GITHUB_TOKEN used by this workflow job has only read-only access to the repository contents, and no unnecessary write privileges. 

In `.github/workflows/release-drafter.yml`, add:

```yaml
permissions:
  contents: read
```

between the `name:` and `on:` blocks (as per the common convention and GitHub Actions YAML structure).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release automation to run only on the main branch and support manual triggers, providing clearer release control.
  - Restricted workflow permissions to read-only for repository contents to enhance security and compliance.
  - This update impacts internal release tooling only; no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->