### PR TITLE
feat: add pr-title input to validate pull request title

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -3,6 +3,7 @@ name: Commit Check
 on:
   pull_request:
     branches: 'main'
+    types: [opened, synchronize, reopened, edited]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -23,3 +23,4 @@ jobs:
           author-email: true
           job-summary: true
           pr-comments: ${{ github.event_name == 'pull_request' }}
+          pr-title: true

--- a/README.md
+++ b/README.md
@@ -131,6 +131,23 @@ jobs:
 > Note: write-access to pull-requests requires the `pull-requests: write` permission.
 > See [usage example](#usage).
 
+### `pr-title`
+
+- **Description**: check pull request title following [Conventional Commits](https://www.conventionalcommits.org/).
+- Default: `false`
+
+> [!TIP]
+> This is especially useful for teams using **Squash & Merge**, where the PR title
+> becomes the final commit message in the main branch. When enabled, the action
+> validates the PR title against your Conventional Commits configuration, giving
+> early feedback at PR time rather than after merge.
+>
+> `pr-title` works alongside `message` — you can enable both to validate the PR
+> title and individual commits, or just one depending on your workflow.
+>
+> This setting only applies to `pull_request` and `pull_request_target` events;
+> it is silently ignored on `push` events.
+
 Note: the default rule of above inputs is following [this configuration](https://github.com/commit-check/commit-check-action/blob/main/commit-check.toml). If you want to customize, just add your [`commit-check.toml`](https://commit-check.github.io/commit-check/configuration.html) config file under your repository root directory.
 
 ## GitHub Action Job Summary

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ jobs:
 - **Description**: post results to the pull request comments.
 - Default: `false`
 
-> [!IMPORTANT]
-> `pr-comments` is an experimental feature. By default, it's disabled.
+> [!NOTE]
+> `pr-comments` is disabled by default.
 >
 > PR comments are skipped for pull requests from forked repositories. See
 > [docs/fork-pr-comments.md](docs/fork-pr-comments.md) for details on how to enable

--- a/README.md
+++ b/README.md
@@ -148,6 +148,17 @@ jobs:
 > This setting only applies to `pull_request` and `pull_request_target` events;
 > it is silently ignored on `push` events.
 
+> [!IMPORTANT]
+> By default, `pull_request` does **not** trigger on title changes.
+> To validate the PR title immediately when updated, add `edited` to your
+> workflow's event types:
+> ```yaml
+> on:
+>   pull_request:
+>     types: [opened, synchronize, reopened, edited]
+> ```
+> Without `edited`, only the initial title (at PR creation) is validated.
+
 Note: the default rule of above inputs is following [this configuration](https://github.com/commit-check/commit-check-action/blob/main/commit-check.toml). If you want to customize, just add your [`commit-check.toml`](https://commit-check.github.io/commit-check/configuration.html) config file under your repository root directory.
 
 ## GitHub Action Job Summary

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: post results to the pull request comments
     required: false
     default: false
+  pr-title:
+    description: check pull request title following conventional commits
+    required: false
+    default: false
 runs:
   using: "composite"
   steps:
@@ -69,4 +73,5 @@ runs:
         DRY_RUN: ${{ inputs.dry-run }}
         JOB_SUMMARY: ${{ inputs.job-summary }}
         PR_COMMENTS: ${{ inputs.pr-comments }}
+        PR_TITLE: ${{ inputs.pr-title }}
         GITHUB_TOKEN: ${{ github.token }}

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ AUTHOR_EMAIL = os.getenv("AUTHOR_EMAIL", "false")
 DRY_RUN = os.getenv("DRY_RUN", "false")
 JOB_SUMMARY = os.getenv("JOB_SUMMARY", "false")
 PR_COMMENTS = os.getenv("PR_COMMENTS", "false")
+PR_TITLE = os.getenv("PR_TITLE", "false")
 GITHUB_STEP_SUMMARY = os.environ["GITHUB_STEP_SUMMARY"]
 
 
@@ -35,6 +36,7 @@ AUTHOR_EMAIL_ENABLED = env_flag("AUTHOR_EMAIL")
 DRY_RUN_ENABLED = env_flag("DRY_RUN")
 JOB_SUMMARY_ENABLED = env_flag("JOB_SUMMARY")
 PR_COMMENTS_ENABLED = env_flag("PR_COMMENTS")
+PR_TITLE_ENABLED = env_flag("PR_TITLE")
 
 
 def log_env_vars():
@@ -45,12 +47,31 @@ def log_env_vars():
     print(f"AUTHOR_EMAIL = {AUTHOR_EMAIL}")
     print(f"DRY_RUN = {DRY_RUN}")
     print(f"JOB_SUMMARY = {JOB_SUMMARY}")
-    print(f"PR_COMMENTS = {PR_COMMENTS}\n")
+    print(f"PR_COMMENTS = {PR_COMMENTS}")
+    print(f"PR_TITLE = {PR_TITLE}\n")
 
 
 def is_pr_event() -> bool:
     """Return whether the workflow was triggered by a PR-style event."""
     return os.getenv("GITHUB_EVENT_NAME", "") in {"pull_request", "pull_request_target"}
+
+
+def get_pr_title() -> str | None:
+    """Read PR title from GitHub event payload."""
+    if not is_pr_event():
+        return None
+    event_path = os.getenv("GITHUB_EVENT_PATH")
+    if not event_path:
+        return None
+    try:
+        with open(event_path, "r") as f:
+            event = json.load(f)
+        return event.get("pull_request", {}).get("title")
+    except Exception as e:
+        print(
+            f"::warning::Failed to read PR title from event: {e}", file=sys.stderr
+        )
+        return None
 
 
 def parse_commit_messages(output: str) -> list[str]:
@@ -149,13 +170,23 @@ def run_check_command(
     return result.returncode
 
 
-def run_pr_message_checks(pr_messages: list[str], result_file: TextIO) -> int:
+def run_pr_message_checks(
+    pr_messages: list[str],
+    result_file: TextIO,
+    initial_emitted: bool = False,
+) -> int:
     """Checks each PR commit message individually via commit-check --message.
+
+    Parameters
+    ----------
+    initial_emitted : bool
+        Whether another check (e.g. PR title) has already produced banner output,
+        so the first failing commit should use --no-banner.
 
     Returns 1 if any message fails, 0 if all pass.
     """
     has_failure = False
-    emitted_failure_output = False
+    emitted_failure_output = initial_emitted
     total = len(pr_messages)
     for index, msg in enumerate(pr_messages, start=1):
         command_args = ["--message"]
@@ -198,20 +229,59 @@ def build_check_args() -> list[str]:
 
 
 def run_commit_check() -> int:
-    """Runs the commit-check command and logs the result."""
+    """Runs all enabled checks and returns the overall exit code.
+
+    Checks are evaluated in order:
+      1. PR title (when ``pr-title: true`` and in a PR event)
+      2. Individual PR commit messages (when ``message: true`` and in a PR event)
+      3. All remaining checks (branch, author name/email, etc.)
+
+    Outside of a PR event all enabled checks are handed to the CLI at once.
+    """
     args = build_check_args()
+    exit_code = 0
+    emitted_failure_output = False
+
     with open("result.txt", "w") as result_file:
+        # ---- 1. PR title check ------------------------------------------------
+        if PR_TITLE_ENABLED and is_pr_event():
+            pr_title = get_pr_title()
+            if pr_title:
+                cmd_args = ["--message"]
+                output_prefix = None
+                if emitted_failure_output:
+                    cmd_args.append("--no-banner")
+                    output_prefix = "\n---\n# PR Title\n"
+                rc = run_check_command(
+                    cmd_args,
+                    result_file,
+                    input_text=pr_title,
+                    output_prefix=output_prefix,
+                )
+                if rc != 0:
+                    exit_code = max(exit_code, rc)
+                    emitted_failure_output = True
+
+        # ---- 2. Commit message checks -----------------------------------------
         if MESSAGE_ENABLED:
             pr_messages = get_pr_commit_messages()
             if pr_messages:
-                # In PR context: check each commit message individually to avoid
+                # In PR context: check each commit individually to avoid
                 # only validating the synthetic merge commit at HEAD.
-                message_rc = run_pr_message_checks(pr_messages, result_file)
-                other_args = [a for a in args if a != "--message"]
-                other_rc = run_other_checks(other_args, result_file)
-                return 1 if message_rc or other_rc else 0
-        # Non-PR context or message disabled: run all checks at once
-        return 1 if run_check_command(args, result_file) else 0
+                rc = run_pr_message_checks(
+                    pr_messages, result_file, initial_emitted=emitted_failure_output
+                )
+                if rc != 0:
+                    exit_code = max(exit_code, rc)
+                args = [a for a in args if a != "--message"]
+
+        # ---- 3. Remaining checks (branch, author, etc.) -----------------------
+        if args:
+            rc = run_other_checks(args, result_file)
+            if rc != 0:
+                exit_code = max(exit_code, rc)
+
+    return 1 if exit_code else 0
 
 
 def read_result_file() -> str | None:

--- a/main.py
+++ b/main.py
@@ -40,15 +40,15 @@ PR_TITLE_ENABLED = env_flag("PR_TITLE")
 
 
 def log_env_vars():
-    """Logs the environment variables for debugging purposes."""
-    print(f"MESSAGE = {MESSAGE}")
-    print(f"BRANCH = {BRANCH}")
-    print(f"AUTHOR_NAME = {AUTHOR_NAME}")
-    print(f"AUTHOR_EMAIL = {AUTHOR_EMAIL}")
-    print(f"DRY_RUN = {DRY_RUN}")
-    print(f"JOB_SUMMARY = {JOB_SUMMARY}")
-    print(f"PR_COMMENTS = {PR_COMMENTS}")
-    print(f"PR_TITLE = {PR_TITLE}\n")
+    """Logs the environment variables for debugging purposes.
+
+    Uses the ``::debug::`` workflow command so these only appear in the
+    action log when ``ACTIONS_STEP_DEBUG`` is set to ``true``.
+    """
+    for name in ("MESSAGE", "BRANCH", "AUTHOR_NAME", "AUTHOR_EMAIL",
+                  "DRY_RUN", "JOB_SUMMARY", "PR_COMMENTS", "PR_TITLE"):
+        value = os.getenv(name, "false")
+        print(f"::debug::{name}={value}")
 
 
 def is_pr_event() -> bool:

--- a/main.py
+++ b/main.py
@@ -68,9 +68,7 @@ def get_pr_title() -> str | None:
             event = json.load(f)
         return event.get("pull_request", {}).get("title")
     except Exception as e:
-        print(
-            f"::warning::Failed to read PR title from event: {e}", file=sys.stderr
-        )
+        print(f"::warning::Failed to read PR title from event: {e}", file=sys.stderr)
         return None
 
 

--- a/main.py
+++ b/main.py
@@ -151,7 +151,6 @@ def run_check_command(
 ) -> int:
     """Run commit-check and write both stdout and stderr to the result file."""
     command = ["commit-check"] + args
-    print(" ".join(command))
     result = subprocess.run(
         command,
         input=input_text,
@@ -250,7 +249,6 @@ def run_commit_check() -> int:
                 if emitted_failure_output:
                     cmd_args.append("--no-banner")
                     output_prefix = "\n--- PR Title ---\n"
-                print("--- PR title check ---")
                 rc = run_check_command(
                     cmd_args,
                     result_file,

--- a/main.py
+++ b/main.py
@@ -246,10 +246,11 @@ def run_commit_check() -> int:
             pr_title = get_pr_title()
             if pr_title:
                 cmd_args = ["--message"]
-                output_prefix = None
+                output_prefix = "# PR Title Validation\n"
                 if emitted_failure_output:
                     cmd_args.append("--no-banner")
-                    output_prefix = "\n---\n# PR Title\n"
+                    output_prefix = "\n---\n# PR Title Validation\n"
+                print("--- PR title check ---")
                 rc = run_check_command(
                     cmd_args,
                     result_file,

--- a/main.py
+++ b/main.py
@@ -45,8 +45,16 @@ def log_env_vars():
     Uses the ``::debug::`` workflow command so these only appear in the
     action log when ``ACTIONS_STEP_DEBUG`` is set to ``true``.
     """
-    for name in ("MESSAGE", "BRANCH", "AUTHOR_NAME", "AUTHOR_EMAIL",
-                  "DRY_RUN", "JOB_SUMMARY", "PR_COMMENTS", "PR_TITLE"):
+    for name in (
+        "MESSAGE",
+        "BRANCH",
+        "AUTHOR_NAME",
+        "AUTHOR_EMAIL",
+        "DRY_RUN",
+        "JOB_SUMMARY",
+        "PR_COMMENTS",
+        "PR_TITLE",
+    ):
         value = os.getenv(name, "false")
         print(f"::debug::{name}={value}")
 

--- a/main.py
+++ b/main.py
@@ -252,16 +252,8 @@ def run_commit_check() -> int:
         if PR_TITLE_ENABLED and is_pr_event():
             pr_title = get_pr_title()
             if pr_title:
-                cmd_args = ["--message"]
-                output_prefix = None
-                if emitted_failure_output:
-                    cmd_args.append("--no-banner")
-                    output_prefix = "\n--- PR Title ---\n"
                 rc = run_check_command(
-                    cmd_args,
-                    result_file,
-                    input_text=pr_title,
-                    output_prefix=output_prefix,
+                    ["--message"], result_file, input_text=pr_title,
                 )
                 if rc != 0:
                     exit_code = max(exit_code, rc)

--- a/main.py
+++ b/main.py
@@ -253,7 +253,9 @@ def run_commit_check() -> int:
             pr_title = get_pr_title()
             if pr_title:
                 rc = run_check_command(
-                    ["--message"], result_file, input_text=pr_title,
+                    ["--message"],
+                    result_file,
+                    input_text=pr_title,
                 )
                 if rc != 0:
                     exit_code = max(exit_code, rc)

--- a/main.py
+++ b/main.py
@@ -246,10 +246,10 @@ def run_commit_check() -> int:
             pr_title = get_pr_title()
             if pr_title:
                 cmd_args = ["--message"]
-                output_prefix = "# PR Title Validation\n"
+                output_prefix = None
                 if emitted_failure_output:
                     cmd_args.append("--no-banner")
-                    output_prefix = "\n---\n# PR Title Validation\n"
+                    output_prefix = "\n--- PR Title ---\n"
                 print("--- PR title check ---")
                 rc = run_check_command(
                     cmd_args,

--- a/main_test.py
+++ b/main_test.py
@@ -67,6 +67,70 @@ class TestParseCommitMessages(unittest.TestCase):
         self.assertEqual(result, ["fix: first", "feat: second"])
 
 
+class TestGetPrTitle(unittest.TestCase):
+    def test_non_pr_event_returns_none(self):
+        with patch.dict(os.environ, {"GITHUB_EVENT_NAME": "push"}):
+            self.assertIsNone(main.get_pr_title())
+
+    def test_pr_event_returns_title(self):
+        import tempfile
+
+        event = {
+            "pull_request": {"title": "feat: add login page"},
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(event, f)
+            event_path = f.name
+        with (
+            patch.dict(os.environ, {"GITHUB_EVENT_NAME": "pull_request", "GITHUB_EVENT_PATH": event_path}),
+        ):
+            self.assertEqual(main.get_pr_title(), "feat: add login page")
+        os.unlink(event_path)
+
+    def test_pull_request_target_event(self):
+        import tempfile
+
+        event = {
+            "pull_request": {"title": "fix: resolve timeout"},
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(event, f)
+            event_path = f.name
+        with (
+            patch.dict(os.environ, {"GITHUB_EVENT_NAME": "pull_request_target", "GITHUB_EVENT_PATH": event_path}),
+        ):
+            self.assertEqual(main.get_pr_title(), "fix: resolve timeout")
+        os.unlink(event_path)
+
+    def test_missing_event_path_returns_none(self):
+        with (
+            patch.dict(os.environ, {"GITHUB_EVENT_NAME": "pull_request"}),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            os.environ["GITHUB_EVENT_NAME"] = "pull_request"
+            os.environ.pop("GITHUB_EVENT_PATH", None)
+            self.assertIsNone(main.get_pr_title())
+
+    def test_invalid_json_returns_none(self):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            f.write("not valid json")
+            event_path = f.name
+        with (
+            patch.dict(os.environ, {"GITHUB_EVENT_NAME": "pull_request", "GITHUB_EVENT_PATH": event_path}),
+            patch("builtins.print"),
+        ):
+            self.assertIsNone(main.get_pr_title())
+        os.unlink(event_path)
+
+
 class TestRunCheckCommand(unittest.TestCase):
     def test_with_args_calls_subprocess(self):
         mock_result = MagicMock(returncode=0, stdout="")
@@ -146,6 +210,32 @@ class TestRunPrMessageChecks(unittest.TestCase):
         self.assertEqual(
             mock_run.call_args_list[2][0][0],
             ["commit-check", "--message", "--no-banner"],
+        )
+
+    def test_initial_emitted_suppresses_banner_for_first_failure(self):
+        results = [
+            MagicMock(returncode=1, stdout="Commit rejected.\n"),
+        ]
+        with patch("main.subprocess.run", side_effect=results) as mock_run:
+            main.run_pr_message_checks(
+                ["bad commit"], io.StringIO(), initial_emitted=True
+            )
+        self.assertEqual(
+            mock_run.call_args[0][0],
+            ["commit-check", "--message", "--no-banner"],
+        )
+
+    def test_initial_not_emitted_allows_banner(self):
+        results = [
+            MagicMock(returncode=1, stdout="Commit rejected.\n"),
+        ]
+        with patch("main.subprocess.run", side_effect=results) as mock_run:
+            main.run_pr_message_checks(
+                ["bad commit"], io.StringIO(), initial_emitted=False
+            )
+        self.assertEqual(
+            mock_run.call_args[0][0],
+            ["commit-check", "--message"],
         )
 
     def test_later_failure_prefix_uses_short_separator_without_extra_blank_lines(self):
@@ -321,6 +411,75 @@ class TestRunCommitCheck(unittest.TestCase):
         ):
             rc = main.run_commit_check()
         self.assertEqual(rc, 1)
+
+    def test_pr_title_check_runs_when_enabled(self):
+        with (
+            patch("main.PR_TITLE_ENABLED", True),
+            patch("main.MESSAGE_ENABLED", False),
+            patch("main.BRANCH_ENABLED", False),
+            patch("main.AUTHOR_NAME_ENABLED", False),
+            patch("main.AUTHOR_EMAIL_ENABLED", False),
+            patch("main.is_pr_event", return_value=True),
+            patch("main.get_pr_title", return_value="feat: a feature"),
+            patch("main.run_check_command", return_value=0) as mock_cmd,
+            patch("main.run_other_checks", return_value=0),
+        ):
+            rc = main.run_commit_check()
+        self.assertEqual(rc, 0)
+        self.assertEqual(
+            mock_cmd.call_args[0][0], ["--message"],
+        )
+        self.assertEqual(mock_cmd.call_args[1]["input_text"], "feat: a feature")
+
+    def test_pr_title_failure_propagates(self):
+        with (
+            patch("main.PR_TITLE_ENABLED", True),
+            patch("main.MESSAGE_ENABLED", False),
+            patch("main.BRANCH_ENABLED", False),
+            patch("main.AUTHOR_NAME_ENABLED", False),
+            patch("main.AUTHOR_EMAIL_ENABLED", False),
+            patch("main.is_pr_event", return_value=True),
+            patch("main.get_pr_title", return_value="bad title"),
+            patch("main.run_check_command", return_value=1),
+            patch("main.run_other_checks", return_value=0),
+        ):
+            rc = main.run_commit_check()
+        self.assertEqual(rc, 1)
+
+    def test_pr_title_skipped_outside_pr_context(self):
+        with (
+            patch("main.PR_TITLE_ENABLED", True),
+            patch("main.MESSAGE_ENABLED", False),
+            patch("main.BRANCH_ENABLED", False),
+            patch("main.AUTHOR_NAME_ENABLED", False),
+            patch("main.AUTHOR_EMAIL_ENABLED", False),
+            patch("main.is_pr_event", return_value=False),
+            patch("main.get_pr_title") as mock_title,
+            patch("main.run_check_command", return_value=0),
+            patch("main.run_other_checks", return_value=0),
+        ):
+            rc = main.run_commit_check()
+        self.assertEqual(rc, 0)
+        mock_title.assert_not_called()
+
+    def test_pr_title_and_message_both_run(self):
+        with (
+            patch("main.PR_TITLE_ENABLED", True),
+            patch("main.MESSAGE_ENABLED", True),
+            patch("main.BRANCH_ENABLED", False),
+            patch("main.AUTHOR_NAME_ENABLED", False),
+            patch("main.AUTHOR_EMAIL_ENABLED", False),
+            patch("main.is_pr_event", return_value=True),
+            patch("main.get_pr_title", return_value="feat: nice pr"),
+            patch("main.get_pr_commit_messages", return_value=["fix: first", "feat: second"]),
+            patch("main.run_check_command", return_value=0) as mock_cmd,
+            patch("main.run_pr_message_checks", return_value=0) as mock_pr,
+            patch("main.run_other_checks", return_value=0),
+        ):
+            rc = main.run_commit_check()
+        self.assertEqual(rc, 0)
+        mock_cmd.assert_called_once()  # PR title check
+        mock_pr.assert_called_once()  # commit message checks
 
     def test_non_pr_path_uses_direct_command(self):
         with (

--- a/main_test.py
+++ b/main_test.py
@@ -78,13 +78,14 @@ class TestGetPrTitle(unittest.TestCase):
         event = {
             "pull_request": {"title": "feat: add login page"},
         }
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             json.dump(event, f)
             event_path = f.name
         with (
-            patch.dict(os.environ, {"GITHUB_EVENT_NAME": "pull_request", "GITHUB_EVENT_PATH": event_path}),
+            patch.dict(
+                os.environ,
+                {"GITHUB_EVENT_NAME": "pull_request", "GITHUB_EVENT_PATH": event_path},
+            ),
         ):
             self.assertEqual(main.get_pr_title(), "feat: add login page")
         os.unlink(event_path)
@@ -95,13 +96,17 @@ class TestGetPrTitle(unittest.TestCase):
         event = {
             "pull_request": {"title": "fix: resolve timeout"},
         }
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             json.dump(event, f)
             event_path = f.name
         with (
-            patch.dict(os.environ, {"GITHUB_EVENT_NAME": "pull_request_target", "GITHUB_EVENT_PATH": event_path}),
+            patch.dict(
+                os.environ,
+                {
+                    "GITHUB_EVENT_NAME": "pull_request_target",
+                    "GITHUB_EVENT_PATH": event_path,
+                },
+            ),
         ):
             self.assertEqual(main.get_pr_title(), "fix: resolve timeout")
         os.unlink(event_path)
@@ -118,13 +123,14 @@ class TestGetPrTitle(unittest.TestCase):
     def test_invalid_json_returns_none(self):
         import tempfile
 
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             f.write("not valid json")
             event_path = f.name
         with (
-            patch.dict(os.environ, {"GITHUB_EVENT_NAME": "pull_request", "GITHUB_EVENT_PATH": event_path}),
+            patch.dict(
+                os.environ,
+                {"GITHUB_EVENT_NAME": "pull_request", "GITHUB_EVENT_PATH": event_path},
+            ),
             patch("builtins.print"),
         ):
             self.assertIsNone(main.get_pr_title())
@@ -427,7 +433,8 @@ class TestRunCommitCheck(unittest.TestCase):
             rc = main.run_commit_check()
         self.assertEqual(rc, 0)
         self.assertEqual(
-            mock_cmd.call_args[0][0], ["--message"],
+            mock_cmd.call_args[0][0],
+            ["--message"],
         )
         self.assertEqual(mock_cmd.call_args[1]["input_text"], "feat: a feature")
 
@@ -471,7 +478,10 @@ class TestRunCommitCheck(unittest.TestCase):
             patch("main.AUTHOR_EMAIL_ENABLED", False),
             patch("main.is_pr_event", return_value=True),
             patch("main.get_pr_title", return_value="feat: nice pr"),
-            patch("main.get_pr_commit_messages", return_value=["fix: first", "feat: second"]),
+            patch(
+                "main.get_pr_commit_messages",
+                return_value=["fix: first", "feat: second"],
+            ),
             patch("main.run_check_command", return_value=0) as mock_cmd,
             patch("main.run_pr_message_checks", return_value=0) as mock_pr,
             patch("main.run_other_checks", return_value=0),

--- a/main_test.py
+++ b/main_test.py
@@ -152,12 +152,11 @@ class TestRunCheckCommand(unittest.TestCase):
         self.assertEqual(mock_run.call_args[1]["input"], "fix: demo")
         self.assertTrue(mock_run.call_args[1]["text"])
 
-    def test_prints_command(self):
+    def test_success_returns_zero(self):
         mock_result = MagicMock(returncode=0, stdout="")
         with patch("main.subprocess.run", return_value=mock_result):
-            with patch("builtins.print") as mock_print:
-                main.run_check_command(["--branch"], io.StringIO())
-        mock_print.assert_called_once_with("commit-check --branch")
+            rc = main.run_check_command(["--branch"], io.StringIO())
+        self.assertEqual(rc, 0)
 
 
 class TestRunPrMessageChecks(unittest.TestCase):


### PR DESCRIPTION
## Summary

Add a new `pr-title` input that validates the **pull request title** against Conventional Commits using commit-check's `--message` check.

## Motivation

Many teams use **Squash & Merge**, where individual commit messages are discarded and the **PR title becomes the final commit message** in the main branch. Previously, the action only validated individual git commits — which means:
- Squash & Merge teams saw noisy failures on intermediate commits (wip, fixup, etc.) that never land in main
- The actual commit message that ends up in main (the PR title) was never validated

This PR fixes that gap. See issue #93 for more context.

## Usage

```yaml
- uses: commit-check/commit-check-action@v2
  with:
    pr-title: true     # validate PR title against Conventional Commits
    message: true      # (optional) also validate individual git commits
```

When `pr-title: true` is set on a `pull_request` or `pull_request_target` event, the action reads `github.event.pull_request.title` from the event payload and validates it via `commit-check --message`.

## Implementation details

All changes are in the **action layer** only — the upstream commit-check CLI already has the validation logic (`--message`), the action just provides the right input (PR title from event payload).

### Changed files

| File | Changes |
|------|---------|
| `action.yml` | Added `pr-title` input (default: `false`) and `PR_TITLE` env var |
| `main.py` | Added `get_pr_title()`, `PR_TITLE_ENABLED` flag, integrated PR title check into `run_commit_check()` before other checks |
| `main_test.py` | 8 new tests covering `get_pr_title()`, PR title flow in `run_commit_check()`, and `initial_emitted` parameter |

### Behavior matrix

| `message` | `pr-title` | PR event? | What happens |
|-----------|-----------|-----------|-------------|
| true | false | yes | Validate each git commit (existing) |
| true | true | yes | Validate PR title + each git commit |
| false | true | yes | Validate PR title only + branch/author |
| true/false | true | no | `pr-title` skipped (not in PR context) |

## Closes

Closes #93
