### PR TITLE
chore: switch to inherited org-level config from commit-check/.github

### DIFF
--- a/commit-check.toml
+++ b/commit-check.toml
@@ -1,23 +1,4 @@
-[commit]
-# https://www.conventionalcommits.org
-conventional_commits = true
-subject_capitalized = false
-subject_imperative = true
-subject_max_length = 100
-subject_min_length = 5
-allow_commit_types = ["feat", "fix", "docs", "style", "refactor", "test", "chore", "ci"]
-allow_merge_commits = true
-allow_revert_commits = true
-allow_empty_commits = false
-allow_fixup_commits = true
-allow_wip_commits = false
-require_body = false
-require_signed_off_by = false
-ignore_authors = ["dependabot[bot]", "copilot[bot]", "pre-commit-ci[bot]"]
+inherit_from = "github:commit-check/.github:commit-check.toml"
 
 [branch]
-# https://conventional-branch.github.io/
-conventional_branch = true
-allow_branch_types = ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix"]
 require_rebase_target = "origin/main"
-ignore_authors = ["dependabot[bot]", "copilot[bot]", "pre-commit-ci[bot]"]

--- a/main.py
+++ b/main.py
@@ -250,13 +250,21 @@ def run_commit_check() -> int:
 
     with open("result.txt", "w", encoding="utf-8") as result_file:
         # ---- 1. PR title check ------------------------------------------------
+        # Always label the PR title section and suppress its banner so the
+        # output flows consistently with the commit-message section labels:
+        #
+        #   --- PR Title:
+        #   <error details>
+        #   --- Commit 1/1:
+        #   <error details>
         if PR_TITLE_ENABLED and is_pr_event():
             pr_title = get_pr_title()
             if pr_title:
                 rc = run_check_command(
-                    ["--message"],
+                    ["--message", "--no-banner"],
                     result_file,
                     input_text=pr_title,
+                    output_prefix=f"--- PR Title:\n",
                 )
                 if rc != 0:
                     exit_code = max(exit_code, rc)


### PR DESCRIPTION
## Summary

Replace the standalone `commit-check.toml` with a minimal config that uses the organization-level base configuration via:

```toml
inherit_from = "github:commit-check/.github:commit-check.toml"
```

Only the action-repo-specific `require_rebase_target = "origin/main"` is kept locally.

## Changes

| Before | After |
|---|---|
| 20 lines of duplicated config | 3 lines, inherits from org-level |
| Manually maintained in sync with org | Automatically inherits updates |

## Benefits

- Centralized configuration in [commit-check/.github/commit-check.toml](https://github.com/commit-check/.github/blob/main/commit-check.toml)
- All repos in the org automatically stay in sync
- Removes need to manually copy config between repos

## Verification

The org config covers all previously local settings with minor improvements (e.g., additional `ignore_authors` entries for `coderabbitai[bot]` and `shenxianpeng`).