### PR TITLE
fix: use temp directory for result file

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 from typing import TextIO
 
 # Constants for message titles
@@ -234,6 +235,17 @@ def build_check_args() -> list[str]:
     return [flag for flag, enabled in flags if enabled]
 
 
+def get_result_path() -> str:
+    """Return a safe path for the result file using a temp directory.
+
+    In GitHub Actions this uses ``RUNNER_TEMP`` which is cleaned up
+    automatically after the job.  Falls back to ``tempfile.gettempdir()``
+    for local testing.
+    """
+    base = os.environ.get("RUNNER_TEMP") or tempfile.gettempdir()
+    return os.path.join(base, "commit-check-result.txt")
+
+
 def run_commit_check() -> int:
     """Runs all enabled checks and returns the overall exit code.
 
@@ -248,7 +260,7 @@ def run_commit_check() -> int:
     exit_code = 0
     emitted_failure_output = False
 
-    with open("result.txt", "w", encoding="utf-8") as result_file:
+    with open(get_result_path(), "w", encoding="utf-8") as result_file:
         # ---- 1. PR title check ------------------------------------------------
         # Always label the PR title section and suppress its banner so the
         # output flows consistently with the commit-message section labels:
@@ -294,8 +306,8 @@ def run_commit_check() -> int:
 
 def read_result_file() -> str | None:
     """Reads the result.txt file and removes ANSI color codes."""
-    if os.path.getsize("result.txt") > 0:
-        with open("result.txt", "r", encoding="utf-8") as result_file:
+    if os.path.getsize(get_result_path()) > 0:
+        with open(get_result_path(), "r", encoding="utf-8") as result_file:
             result_text = re.sub(
                 r"\x1B\[[0-9;]*[a-zA-Z]", "", result_file.read()
             )  # Remove ANSI colors

--- a/main_test.py
+++ b/main_test.py
@@ -383,10 +383,12 @@ class TestRunCommitCheck(unittest.TestCase):
         import tempfile
 
         self._tmpdir = tempfile.mkdtemp()
+        os.environ["RUNNER_TEMP"] = self._tmpdir
         os.chdir(self._tmpdir)
 
     def tearDown(self):
         os.chdir(self._orig_dir)
+        os.environ.pop("RUNNER_TEMP", None)
 
     def test_pr_path_calls_pr_message_checks(self):
         with (
@@ -433,7 +435,7 @@ class TestRunCommitCheck(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertEqual(
             mock_cmd.call_args[0][0],
-            ["--message"],
+            ["--message", "--no-banner"],
         )
         self.assertEqual(mock_cmd.call_args[1]["input_text"], "feat: a feature")
 
@@ -528,7 +530,7 @@ class TestRunCommitCheck(unittest.TestCase):
             patch("main.run_check_command", return_value=0),
         ):
             main.run_commit_check()
-        self.assertTrue(os.path.exists(os.path.join(self._tmpdir, "result.txt")))
+        self.assertTrue(os.path.exists(main.get_result_path()))
 
     def test_other_args_excludes_message(self):
         captured_args = []
@@ -557,13 +559,15 @@ class TestReadResultFile(unittest.TestCase):
 
         self._orig_dir = os.getcwd()
         self._tmpdir = tempfile.mkdtemp()
+        os.environ["RUNNER_TEMP"] = self._tmpdir
         os.chdir(self._tmpdir)
 
     def tearDown(self):
         os.chdir(self._orig_dir)
+        os.environ.pop("RUNNER_TEMP", None)
 
     def _write_result(self, content: str):
-        with open("result.txt", "w", encoding="utf-8") as file_obj:
+        with open(main.get_result_path(), "w", encoding="utf-8") as file_obj:
             file_obj.write(content)
 
     def test_empty_file_returns_none(self):
@@ -595,12 +599,14 @@ class TestAddJobSummary(unittest.TestCase):
 
         self._orig_dir = os.getcwd()
         self._tmpdir = tempfile.mkdtemp()
+        os.environ["RUNNER_TEMP"] = self._tmpdir
         os.chdir(self._tmpdir)
-        with open("result.txt", "w", encoding="utf-8"):
+        with open(main.get_result_path(), "w", encoding="utf-8"):
             pass
 
     def tearDown(self):
         os.chdir(self._orig_dir)
+        os.environ.pop("RUNNER_TEMP", None)
 
     def test_false_skips(self):
         with patch("main.JOB_SUMMARY_ENABLED", False):
@@ -641,12 +647,14 @@ class TestAddPrComments(unittest.TestCase):
 
         self._orig_dir = os.getcwd()
         self._tmpdir = tempfile.mkdtemp()
+        os.environ["RUNNER_TEMP"] = self._tmpdir
         os.chdir(self._tmpdir)
-        with open("result.txt", "w", encoding="utf-8"):
+        with open(main.get_result_path(), "w", encoding="utf-8"):
             pass
 
     def tearDown(self):
         os.chdir(self._orig_dir)
+        os.environ.pop("RUNNER_TEMP", None)
 
     def test_disabled_returns_zero(self):
         with patch("main.PR_COMMENTS_ENABLED", False):
@@ -777,12 +785,14 @@ class TestMain(unittest.TestCase):
 
         self._orig_dir = os.getcwd()
         self._tmpdir = tempfile.mkdtemp()
+        os.environ["RUNNER_TEMP"] = self._tmpdir
         os.chdir(self._tmpdir)
-        with open("result.txt", "w", encoding="utf-8"):
+        with open(main.get_result_path(), "w", encoding="utf-8"):
             pass
 
     def tearDown(self):
         os.chdir(self._orig_dir)
+        os.environ.pop("RUNNER_TEMP", None)
 
     def test_success_path(self):
         with (


### PR DESCRIPTION
## Summary

Replace the hardcoded `"result.txt"` (written to `GITHUB_WORKSPACE`) with a path under `RUNNER_TEMP`, the GitHub Actions temp directory that is auto-cleaned after each job.

## Changes

- **main.py**: Added `get_result_path()` — uses `RUNNER_TEMP` env var (`commit-check-result.txt` under it) or falls back to `tempfile.gettempdir()`
- **main.py**: `run_commit_check()` and `read_result_file()` now call `get_result_path()` instead of hardcoding `"result.txt"`
- **main_test.py**: Updated `setUp`/`tearDown` in 5 test classes to set/unset `RUNNER_TEMP` so tests write to the expected location
- **main_test.py**: Fixed pre-existing assertion (`test_pr_title_check_runs_when_enabled` expected `["--message"]` but actual is `["--message", "--no-banner"]`)

## Why

Writing to the current working directory in a GitHub Action can overwrite files in the user's repository. `RUNNER_TEMP` is the safe, documented location for temporary files.

Closes #N/A