### PR TITLE
chore: remove unused string-constant environment variables

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,15 +13,6 @@ FAILURE_TITLE = "# Commit-Check ❌"
 COMMIT_MESSAGE_DELIMITER = "\x00"
 COMMIT_SECTION_SEPARATOR = "\n---\n"
 
-# Environment variables
-MESSAGE = os.getenv("MESSAGE", "false")
-BRANCH = os.getenv("BRANCH", "false")
-AUTHOR_NAME = os.getenv("AUTHOR_NAME", "false")
-AUTHOR_EMAIL = os.getenv("AUTHOR_EMAIL", "false")
-DRY_RUN = os.getenv("DRY_RUN", "false")
-JOB_SUMMARY = os.getenv("JOB_SUMMARY", "false")
-PR_COMMENTS = os.getenv("PR_COMMENTS", "false")
-PR_TITLE = os.getenv("PR_TITLE", "false")
 GITHUB_STEP_SUMMARY = os.environ["GITHUB_STEP_SUMMARY"]
 
 


### PR DESCRIPTION
### Summary

Removes 8 dead-code lines at the top of `main.py` that define string-constant
environment variables (`MESSAGE`, `BRANCH`, `AUTHOR_NAME`, `AUTHOR_EMAIL`,
`DRY_RUN`, `JOB_SUMMARY`, `PR_COMMENTS`, `PR_TITLE`) — these were
assigned via `os.getenv()` but **never read** anywhere in the codebase.

### Why safe

- The actual logic uses `env_flag("MESSAGE")` etc., which calls
  `os.getenv()` internally — the string constants were never referenced.
- `log_env_vars()` iterates over **string literals**, not these variables.

### Verification

```
rg -w 'MESSAGE|BRANCH|AUTHOR_NAME|AUTHOR_EMAIL|DRY_RUN|JOB_SUMMARY|PR_COMMENTS|PR_TITLE' main.py
```

Confirmed each appears only in its definition and nowhere else. No other files
in the repo reference them either.