### PR TITLE
chore: allow branch names starting with create-pull-request/

### DIFF
--- a/commit-check.toml
+++ b/commit-check.toml
@@ -2,3 +2,4 @@ inherit_from = "github:commit-check/.github:commit-check.toml"
 
 [branch]
 require_rebase_target = "origin/main"
+allow_branch_names = ["create-pull-request/.+"]


### PR DESCRIPTION
## Summary

Fixes #225 by adding `allow_branch_names = ["create-pull-request/.+"]` to `commit-check.toml`.

## Background

The `peter-evans/create-pull-request` GitHub Action creates branches like `create-pull-request/patch`. These branches were being rejected by commit-check because `create-pull-request` is not one of the allowed branch types in the inherited org-level conventional branch configuration.

## Change

Added `allow_branch_names` to the local `[branch]` section in `commit-check.toml`:

```toml
[branch]
require_rebase_target = "origin/main"
allow_branch_names = ["create-pull-request/.+"]
```

This works alongside `conventional_branch = true` (inherited from the org-level config) by providing an explicit allow-list of branch name patterns that bypass the conventional branch type check.

## Testing

The regex `create-pull-request/.+` correctly matches branch names like:
- `create-pull-request/patch`
- `create-pull-request/some-update`

And still validates all other branches against the conventional branch spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded branch name validation to allow `create-pull-request/*` branches, making automated pull request workflows more flexible.
  * Existing rebase requirements remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->