### PR TITLE
docs: add Discussions link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,4 +267,4 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## Have questions or feedback?
 
-To provide feedback (requesting a feature or reporting a bug), please post to [issues](https://github.com/commit-check/commit-check/issues).
+To provide feedback (requesting a feature or reporting a bug), please post to [issues](https://github.com/commit-check/commit-check/issues) or start a [discussion](https://github.com/commit-check/commit-check/discussions).


### PR DESCRIPTION
The commit-check project has Discussions enabled, but this Action's README only references Issues. Added a link to Discussions so users know where to ask questions and share ideas.\n\nSee: https://github.com/commit-check/commit-check/discussions