### PR TITLE
chore: disable dependabot cooldown for pip updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,5 @@ updates:
     directory: /
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 0


### PR DESCRIPTION
Dependabot applies a default 3-day cooldown to version updates, which delays dependency bump PRs (e.g. commit-check v2.12.2 was published but skipped because it was within the cooldown window).

Set `cooldown.default-days: 0` for the pip ecosystem so new releases are considered immediately. See [Dependabot docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated Python package update settings with a cooldown configuration.
  * Dependency updates can now be processed without a default waiting period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->