### PR TITLE
docs: move documentation links to the project domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,13 +186,13 @@ Set any `CCHK_*` environment variable in your workflow step — no config file r
 
 All available environment variables follow the naming convention:
 `CCHK_` + uppercase option name with underscores instead of hyphens. See the
-[full mapping](https://commit-check.github.io/commit-check/configuration.html#environment-variables)
+[full mapping](https://docs.commit-check.com/configuration.html#environment-variables)
 in the commit-check documentation.
 
 ### Via Configuration File
 
 Add a `commit-check.toml` or `cchk.toml` to the root of your repository.
-Refer to the [configuration guide](https://commit-check.github.io/commit-check/configuration.html)
+Refer to the [configuration guide](https://docs.commit-check.com/configuration.html)
 for all available options.
 
 > [!NOTE]


### PR DESCRIPTION
## Summary

The commit-check documentation is now served from its own domain. Update the two configuration links in the README:

- The environment variable mapping link
- The configuration guide link

Both now point at `docs.commit-check.com` instead of the `github.io` path.

## Notes

Existing links keep working — GitHub Pages redirects the old `github.io` URLs to the custom domain — so this is a tidy-up rather than a fix for anything broken.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EP4xvwiuE98BeYSpe7EbyB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration documentation links to point to the new documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->