### PR TITLE
docs: point documentation links at commit-check.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,13 +186,13 @@ Set any `CCHK_*` environment variable in your workflow step — no config file r
 
 All available environment variables follow the naming convention:
 `CCHK_` + uppercase option name with underscores instead of hyphens. See the
-[full mapping](https://docs.commit-check.com/configuration.html#environment-variables)
+[full mapping](https://commit-check.com/configuration/#environment-variables)
 in the commit-check documentation.
 
 ### Via Configuration File
 
 Add a `commit-check.toml` or `cchk.toml` to the root of your repository.
-Refer to the [configuration guide](https://docs.commit-check.com/configuration.html)
+Refer to the [configuration guide](https://commit-check.com/configuration/)
 for all available options.
 
 > [!NOTE]


### PR DESCRIPTION
The documentation moved to [commit-check/commit-check.com](https://github.com/commit-check/commit-check.com) and is served from the apex domain.

Updates the two `README.md` links, which also still used the Sphinx-era `.html` URLs:

- `docs.commit-check.com/configuration.html#environment-variables` → `commit-check.com/configuration/#environment-variables`
- `docs.commit-check.com/configuration.html` → `commit-check.com/configuration/`

Safe to merge at any time — `docs.commit-check.com` keeps serving until it is retired, so neither the old nor the new URL is broken during the transition.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Advanced Configuration documentation links to point to the current website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->