### PR TITLE
docs: add commit-check.com link to config header

### DIFF
--- a/commit-check.toml
+++ b/commit-check.toml
@@ -1,3 +1,5 @@
+# Learn more: https://commit-check.com
+
 inherit_from = "github:commit-check/.github:commit-check.toml"
 
 [branch]


### PR DESCRIPTION
Adds the official website link at the top of `commit-check.toml` to increase site exposure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a reference link to the commit-check website in the configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->