### PR TITLE
ci: write the job summary from one matrix leg, not three

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -25,7 +25,11 @@ jobs:
           branch: true
           author-name: true
           author-email: true
-          job-summary: true
-          # Only post PR comments from the ubuntu job to avoid duplicates
+          # Report from the ubuntu job only. Every leg checks the same commits
+          # against the same rules, so the other two produce a byte-identical
+          # report — three copies of it on the run page, and the matrix is here
+          # to prove the action runs on each OS, not to say the same thing
+          # three times.
+          job-summary: ${{ matrix.os == 'ubuntu-latest' }}
           pr-comments: ${{ github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest' }}
           pr-title: true


### PR DESCRIPTION
The run page currently shows three summaries:

```
commit-check (ubuntu-latest) summary
commit-check (macos-latest) summary
commit-check (windows-latest) summary
```

All three are byte-identical. Every leg checks the same commits against the
same rules, so the report cannot differ between them — the matrix is here to
prove the action runs on each OS, not to say the same thing three times.

`pr-comments` was already guarded exactly this way two lines below, to stop
the same duplication on the comment surface. This applies the same guard to
the surface that was still missing it:

```yaml
job-summary: ${{ matrix.os == 'ubuntu-latest' }}
```

The other two legs still run every check and still fail the job on a
violation — they just stop writing a duplicate report.

### Why not rename it to plain `commit-check summary`

That heading text is generated by GitHub from the job name, and a matrix
job's name is `<job-id> (<matrix values>)`. Getting the suffix off it means
splitting this into a reporting job plus a separate cross-platform job, which
changes the check names and would need any required-status-check settings on
`main` updated to match. Not worth it for the suffix; out of scope here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9zFxq8V4qxG4aMzJhGBFn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow reporting so job summaries are generated only for the Ubuntu matrix job.
  * Preserved pull-request comment reporting for Ubuntu jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->