### PR TITLE
docs: add cpp-linter to Used By, and restore a lost separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ jobs:
   <a href="https://github.com/opencadc"><img src="https://avatars.githubusercontent.com/u/13909060?s=200&v=4" alt="OpenCADC" width="28"/></a>
   <strong>OpenCADC</strong>&nbsp;&nbsp;
   <a href="https://github.com/extrawest"><img src="https://avatars.githubusercontent.com/u/39154663?s=200&v=4" alt="Extrawest" width="28"/></a>
-  <strong>Extrawest</strong>
+  <strong>Extrawest</strong>&nbsp;&nbsp;
   <a href="https://github.com/Chainlift"><img src="https://avatars.githubusercontent.com/u/204404276?s=200&v=4" alt="Chainlift" width="28"/></a>
   <strong>Chainlift</strong>&nbsp;&nbsp;
   <a href="https://github.com/mila-iqia"><img src="https://avatars.githubusercontent.com/u/11724251?s=200&v=4" alt="Mila" width="28"/></a>
@@ -86,6 +86,8 @@ jobs:
   <strong>RLinf</strong>&nbsp;&nbsp;
   <a href="https://github.com/collective"><img src="https://avatars.githubusercontent.com/u/362867?s=200&v=4" alt="Collective" width="28"/></a>
   <strong>Collective</strong>&nbsp;&nbsp;
+  <a href="https://github.com/cpp-linter"><img src="https://avatars.githubusercontent.com/cpp-linter?s=200&v=4" alt="cpp-linter" width="28"/></a>
+  <strong>cpp-linter</strong>&nbsp;&nbsp;
   <strong> and <a href="https://github.com/commit-check/commit-check-action/network/dependents">many more</a>.</strong>
 </p>
 


### PR DESCRIPTION
Adds `cpp-linter` to the Used By row.

Two notes on it:

- The avatar is addressed by login (`avatars.githubusercontent.com/cpp-linter`)
  rather than by numeric id like the other nine. The numeric id is not
  reachable from this session, and the login form serves the same image
  (verified `200 image/png`).
- I could not verify the usage itself from here — `cpp-linter` is outside this
  session's repository scope, so this rests on your own check, same as the
  rest of the row.

### Also: a spacing bug that was already there

`Extrawest` was missing its trailing `&nbsp;&nbsp;`, so it ran straight into
`Chainlift` with no gap:

```
... OpenCADC   Extrawest ExtrawestChainlift Chainlift   Mila ...
```

Every other entry has the separator; this one lost it. Only visible in the
rendered row, which is why it survived — the source lines look identical at a
glance.

### Not changed

`RLinf` links to `github.com/RLinf/RLinf` (a repo) while all nine others link
to an org. The avatar is the org's, so this looks like an oversight — but it
is your curation and you may have pinned the specific repo deliberately, so I
left it. Say the word if it should point at the org.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9zFxq8V4qxG4aMzJhGBFn)_