### PR TITLE
ci: run the unit tests, which nothing was running

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: Test
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        # The floor and the newest. 3.10 is the real floor: main.py annotates
+        # with `str | None` and has no `from __future__ import annotations`, so
+        # the annotation is evaluated at def time, and main_test.py uses
+        # parenthesized context managers. Both are 3.10+.
+        #
+        # The action itself runs on whatever python3 the runner ships, so the
+        # in-between versions add little here — unlike commit-check, which is a
+        # published package and tests every one.
+        py: ['3.10', '3.14']
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.py }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # requirements.txt rather than a bare install: it pins the same
+          # commit-check the action ships, which is the version the golden
+          # tests expect to read back out of importlib.metadata.
+          python -m pip install -r requirements.txt pytest
+
+      - name: Run unit tests
+        run: python -m pytest main_test.py -v


### PR DESCRIPTION
`main_test.py` has 99 tests and **CI has never executed one of them.**

The four existing workflows are `commit-check` (the action self-testing),
`pre-commit` (black, mypy, codespell, yaml/toml checks), `release` and
`used-by`. None invokes pytest. Every release so far shipped with the suite
unrun anywhere except a contributor's machine — including the v2.13.0 draft
sitting ready now.

### The matrix

The floor and the newest, across the three OSes the action supports — 6 jobs.

`3.10` is the real floor, not a guess:

- `main.py` annotates with `str | None` and has no
  `from __future__ import annotations`, so the annotation is evaluated at
  `def` time — PEP 604 at runtime is 3.10+.
- `main_test.py` uses parenthesized context managers in 34 places — 3.10+.

The in-between versions earn less here than they do in `commit-check`: that
is a published package installed into whatever interpreter a user has, while
this action runs on whatever `python3` its runner ships.

`fail-fast: false` so a failure on one OS doesn't mask the others — worth
having on a suite CI has never run before.

### Why `requirements.txt` and not bare deps

It pins the same `commit-check` the action ships, which is also the version
the golden tests read back out of `importlib.metadata`. Installing anything
else would make `PINNED_VERSION` in the test file and the shipped version
drift apart silently.

### Verified

The exact install and pytest invocation this workflow runs, from a clean venv:

```
commit-check       2.13.1
PyGithub           2.9.1
pytest             9.1.1
99 passed, 2 subtests passed in 0.19s
```

Actions are SHA-pinned with version comments, matching the convention in
`commit-check/.github/workflows/main.yml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9zFxq8V4qxG4aMzJhGBFn)_