### PR TITLE
fix: drop the header logo, which read as a second status signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ ran.
 
 Passing runs stay to one line, with the detail folded away:
 
-> <img src="https://raw.githubusercontent.com/commit-check/commit-check-action/main/assets/logo.png" width="24" align="top" alt=""> **Commit Check**
+> **Commit Check**
 >
 > ✅ **All 3 checks passed**
 >
@@ -266,7 +266,7 @@ Passing runs stay to one line, with the detail folded away:
 Failures open with a count, then a table of only the scopes that failed — every
 rule ID links to its documentation — with the full tree still one click away:
 
-> <img src="https://raw.githubusercontent.com/commit-check/commit-check-action/main/assets/logo.png" width="24" align="top" alt=""> **Commit Check**
+> **Commit Check**
 >
 > ❌ **2 of 4 checks failed**
 >

--- a/main.py
+++ b/main.py
@@ -29,27 +29,23 @@ RULES_URL = "https://commit-check.com/rules/"
 # CodSpeed all use for the same purpose.
 COMMENT_MARKER = "<!-- commit-check-action -->"
 
-#: Logo shown next to the report title.
-#
-# Served from this repository rather than commit-check.com so the report has no
-# cross-repository dependency, and as PNG rather than SVG because GitHub proxies
-# comment images through camo, which handles SVG unreliably. Point this at a
-# single org-wide asset if the other tools grow the same header.
-#
-# This is the org's *filled* mark (branding/avatar.png), not the transparent
-# logo-mark. At this size a stroke has almost no visual weight -- the wordless
-# mark rendered as a faint tick, worst on dark backgrounds -- while a filled
-# tile holds up. It is the asset the branding README calls out as legible
-# small, and the width below matches the h2 cap height so the icon is not
-# smaller than the words next to it.
-LOGO_URL = (
-    "https://raw.githubusercontent.com/commit-check/commit-check-action/main/"
-    "assets/logo.png"
-)
-
 #: Report heading. h2 rather than h1: this renders inside a PR comment, where an
 #: h1 is louder than anything else on the page.
-REPORT_TITLE = f'## <img src="{LOGO_URL}" width="24" align="top" alt=""> Commit Check'
+#
+# Deliberately carries no logo. The org mark is a check inside a rounded tile,
+# which is the same object GitHub's ✅ is — same shape, same silhouette, only
+# the hue differs. Putting it immediately above the verdict line meant a failing
+# report opened with a tick and then said "❌ 2 of 4 checks failed": the first
+# symbol the eye lands on contradicted the second, and it did so precisely when
+# the reader most needs to read the result quickly.
+#
+# The verdict line is the one status signal in this report, and one is the right
+# number. "Commit Check" in words is unambiguous branding; a checkmark next to a
+# failure is not.
+#
+# Do not "fix" this by showing the logo only on success — that makes the logo's
+# presence itself a status signal, which is the same defect wearing a hat.
+REPORT_TITLE = "## Commit Check"
 
 #: Prefixes of report bodies written by earlier versions, kept so the first run
 #: after upgrading adopts the existing comment instead of posting a second one.
@@ -574,7 +570,7 @@ def _scope_value(scope: ScopeResult, max_len: int = 60) -> str:
 # Success:
 #
 #   <!-- commit-check-action -->
-#   ## <img src="..." width="24" align="top" alt=""> Commit Check
+#   ## Commit Check
 #
 #   ✅ **All 5 checks passed**
 #
@@ -599,7 +595,7 @@ def _scope_value(scope: ScopeResult, max_len: int = 60) -> str:
 # Failure:
 #
 #   <!-- commit-check-action -->
-#   ## <img src="..." width="24" align="top" alt=""> Commit Check
+#   ## Commit Check
 #
 #   ❌ **1 of 5 checks failed**
 #


### PR DESCRIPTION
## The problem

Raised by @shenxianpeng looking at a failing report: *is this thing telling me it passed or failed?*

The org mark is a white check inside a rounded tile. GitHub's `✅` is a white check inside a rounded square. **Same shape, same silhouette — only the hue differs**, and hue is the weakest channel to carry meaning at 24px.

So a failing report read:

```
[✓ tile]  Commit Check
❌ 2 of 4 checks failed
```

The first symbol the eye lands on contradicts the second — and it does so exactly when the reader most needs to take the result in at a glance.

**Success was fine**, both symbols agreeing. That is what hid it: the ambiguity appears *only* on failure, which is the case that matters most and the one you see least while building the thing.

## How it got here

Three changes, each locally reasonable:

| | header art | how it read |
|---|---|---|
| originally | wordmark badge with "COMMIT" in it | a logo |
| #259 | new wordless mark, transparent | faint decoration |
| #261 | same mark, filled tile | **a status chip** |

#261 set out to give the mark presence. Adding visual weight added semantic weight with it — that's the bit I got wrong there, and this reverses it.

## What changed

The header is now plain `## Commit Check`. The verdict line is the single status signal, which is the right number of them; the words carry the brand without claiming an outcome.

Also updated: the two header mockups in `main.py`'s output-spec comment, and the two rendered previews in the README, so the documented layout matches what ships.

`LOGO_URL` is gone since nothing references it. **`assets/logo.png` stays** — unreferenced by this repo now, but the raw URL is public and may be linked from outside, and 2.8 KB is cheaper than a broken image somewhere I can't see.

## Why not the alternatives

- **Move the mark to the footer** — quieter, but a tick in a failed report's footer is still a tick. Treats the symptom.
- **Show the logo only on success** — this makes the logo's *presence* a status signal, which is the same defect wearing a hat. The code comment says so, to stop it being "fixed" that way later.

## Verification

- Comment identity is unaffected: comments are matched on `COMMENT_MARKER`, an invisible HTML comment, **not** on the title — so existing comments are still adopted and edited in place rather than duplicated. (`_find_own_comments` only falls back to `LEGACY_TITLES` when no marked comment exists.)
- `99 passed`, black clean. The golden tests build their expected header from `main.REPORT_TITLE`, so they followed the change without edits — the layout is still pinned exactly.
- Rendered a real failure report to confirm the output, rather than reasoning about the template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9zFxq8V4qxG4aMzJhGBFn

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9zFxq8V4qxG4aMzJhGBFn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified job summary and PR report headings by removing the Commit Check logo image.
  * Updated success and failure output examples to display a plain “Commit Check” heading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->