### PR TITLE
fix: pass codecov token for uploads to protected main branch

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          # Required: main is a protected branch, so Codecov rejects tokenless uploads.
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           flags: unittests
           name: codecov-umbrella


### PR DESCRIPTION
## What

The merged Coverage workflow failed on `main`:

```
error: Upload queued for processing failed: {"message":"Token required because branch is protected"}
```

Tokenless uploads only work for unprotected branches — `main` is protected, so Codecov rejects the upload. The action was run without a `token` input, so the upload was unauthenticated.

## Fix

Pass `token: ${{ secrets.CODECOV_TOKEN }}` to `codecov/codecov-action` (same as the sibling repo commit-check does). The `CODECOV_TOKEN` secret is already configured in this repo.

Everything else (SHA pins, `fail_ci_if_error` on push only) is unchanged.