### PR TITLE
fix(docs): fork checkout needs allow-unsafe-pr-checkout, and an honest skip message

### DIFF
--- a/docs/fork-pr-comments.md
+++ b/docs/fork-pr-comments.md
@@ -19,11 +19,14 @@ Everything except the comment. The action does not degrade on a fork PR:
 So a contributor pushing to a fork already gets the red check, the per-finding annotations
 on their diff, and the whole report in the job summary. The action says so in the log:
 
-```
+```text
 ::warning::Skipping PR comment: pull requests from forked repositories cannot write
 comments via the pull_request event (GITHUB_TOKEN is read-only for forks). The findings
 are in this job's summary and in the annotations on the Files changed tab.
 ```
+
+(with `job-summary: false` the message names the annotations alone, since there is no
+summary to read.)
 
 The run is **not** failed by this: `pr-comments: true` on a fork PR is a no-op, not an error.
 
@@ -73,6 +76,10 @@ jobs:
         with:
           ref: refs/pull/${{ github.event.number }}/merge   # the PR's commits
           fetch-depth: 0
+          # Required since checkout v7: without it the step refuses to place
+          # fork code in a pull_request_target job, and this workflow never
+          # reaches the action below.
+          allow-unsafe-pr-checkout: true
       - uses: commit-check/commit-check-action@v2
         with:
           message: true
@@ -81,11 +88,15 @@ jobs:
 ```
 
 > [!WARNING]
-> `pull_request_target` grants a writable token to a workflow whose checkout contains the
-> fork's code. commit-check only *reads* commit metadata and never executes the checked-out
-> tree, but any other step you add to this job runs with that token. Keep the job to the
-> checkout and this action, never cache or build from it, and never expose secrets to it.
-> See [GitHub's guidance on `pull_request_target`](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/).
+> This is the "pwn request" shape, and `allow-unsafe-pr-checkout: true` is the switch
+> `actions/checkout` makes you flip to acknowledge it. The job runs with the base
+> repository's `GITHUB_TOKEN`, its secrets, its cache scope and its runner, and the
+> checkout puts the fork's code on that runner. commit-check only *reads* commit metadata
+> and never executes the checked-out tree, but any other step you add to this job would.
+> Keep the job to exactly these two steps, never build, install or cache from the tree,
+> and never expose secrets to it. Read
+> [Securely using `pull_request_target`](https://gh.io/securely-using-pull_request_target)
+> before turning this on.
 
 ## What this page used to describe
 

--- a/main.py
+++ b/main.py
@@ -1477,11 +1477,15 @@ def add_pr_comments(results: list[ScopeResult]) -> int:
     # the GitHub API will always reject comment writes with 403.
     # pull_request_target events always have the configured token permissions.
     if is_fork_pr_with_readonly_token():
+        # Name only the surfaces this run actually produced: with
+        # job-summary: false there is no summary to send the reader to.
+        where = "in the annotations on the Files changed tab"
+        if JOB_SUMMARY_ENABLED and GITHUB_STEP_SUMMARY:
+            where = f"in this job's summary and {where}"
         msg = (
             "Skipping PR comment: pull requests from forked repositories "
             "cannot write comments via the pull_request event (GITHUB_TOKEN is "
-            "read-only for forks). The findings are in this job's summary and "
-            "in the annotations on the Files changed tab. "
+            f"read-only for forks). The findings are {where}. "
             "See https://github.com/commit-check/commit-check-action/blob/main/docs/fork-pr-comments.md"
         )
         print(f"::warning::{msg}")

--- a/main_test.py
+++ b/main_test.py
@@ -1900,6 +1900,37 @@ class TestAddPrComments(unittest.TestCase):
         self.assertIn("::warning::", printed)
         self.assertIn("read-only", printed)
 
+    def test_fork_pr_warning_names_only_the_surfaces_that_exist(self):
+        """With job-summary: false the warning must not send the reader to a
+        summary this run never wrote; the annotations are still named."""
+        summary_path = os.path.join(tempfile.mkdtemp(), "summary.txt")
+        with (
+            patch("main.PR_COMMENTS_ENABLED", True),
+            patch.dict(os.environ, {"GITHUB_EVENT_NAME": "pull_request"}),
+            patch("main.is_fork_pr", return_value=True),
+            patch("main.JOB_SUMMARY_ENABLED", False),
+            patch("main.GITHUB_STEP_SUMMARY", summary_path),
+            patch("builtins.print") as mock_print,
+        ):
+            rc = main.add_pr_comments([pass_scope()])
+        self.assertEqual(rc, 0)
+        printed = mock_print.call_args[0][0]
+        self.assertIn("annotations on the Files changed tab", printed)
+        self.assertNotIn("job's summary", printed)
+        self.assertFalse(os.path.exists(summary_path))
+
+        with (
+            patch("main.PR_COMMENTS_ENABLED", True),
+            patch.dict(os.environ, {"GITHUB_EVENT_NAME": "pull_request"}),
+            patch("main.is_fork_pr", return_value=True),
+            patch("main.JOB_SUMMARY_ENABLED", True),
+            patch("main.GITHUB_STEP_SUMMARY", summary_path),
+            patch("builtins.print") as mock_print,
+        ):
+            main.add_pr_comments([pass_scope()])
+        printed = mock_print.call_args[0][0]
+        self.assertIn("in this job's summary and in the annotations", printed)
+
     def test_fork_pr_writes_job_summary_hint(self):
         summary_path = os.path.join(tempfile.mkdtemp(), "summary.txt")
         with (


### PR DESCRIPTION
## Why this is a separate PR

These three fixes were pushed to #279 while it was being merged, so the squash took `0db5e82` and left them behind. They apply to `docs/fork-pr-comments.md` and the fork skip message that #279 introduced.

## What

### The documented `pull_request_target` fallback cannot work as written

`actions/checkout` added an `allow-unsafe-pr-checkout` input (v4.4.0, present in v7.0.1) that defaults to `false` and **blocks** checking out fork pull-request code from a `pull_request_target` or `workflow_run` job. The example in #279 omits it, so checkout stops and the workflow never reaches `commit-check/commit-check-action@v2`.

Verified against the source rather than taken on trust — `raw.githubusercontent.com/actions/checkout/v7.0.1/action.yml`:

```yaml
allow-unsafe-pr-checkout:
  description: >
    Required to check out fork pull request code from a workflow triggered by
    `pull_request_target` or `workflow_run`. These workflows run with the
    base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and
    runner access; fetching and executing a fork's code in that trusted
    context commonly leads to "pwn request" vulnerabilities. …
  default: false
```

The input is now in the example, and the warning beside it is rewritten around what checkout itself says: this is the "pwn request" shape, the input is the switch that makes you acknowledge it, the job holds the base repository's token, secrets, cache scope and runner, and the checkout puts the fork's code on that runner. The link now points at GitHub's own [Securely using `pull_request_target`](https://gh.io/securely-using-pull_request_target) instead of a third-party write-up.

### The fork skip message promised a job summary that may not exist

With `job-summary: false` no summary is written, but the warning still sent the reader to one. It now names the annotations alone in that case, and both surfaces when the summary is enabled.

```python
where = "in the annotations on the Files changed tab"
if JOB_SUMMARY_ENABLED and GITHUB_STEP_SUMMARY:
    where = f"in this job's summary and {where}"
```

A test pins both wordings and asserts no summary file is created in the disabled case. Reverting the condition to the previous unconditional text makes it fail, which is how I checked it actually covers the change.

### MD040

The log excerpt in the docs gets a `text` language tag.

## Verification

- `pytest`: 194 passed, 8 subtests. `pre-commit run --all-files` clean.
- The doc's YAML example parses and carries `allow-unsafe-pr-checkout: true`.
- Both opening fences in the page now carry a language tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xYa7m3qup5wyN5MaXFgf6

---
_Generated by [Claude Code](https://claude.ai/code/session_018xYa7m3qup5wyN5MaXFgf6)_